### PR TITLE
Subscribers status propogation should happen for duck v1beta1

### DIFF
--- a/pkg/reconciler/channel/channel.go
+++ b/pkg/reconciler/channel/channel.go
@@ -97,7 +97,7 @@ func (r *Reconciler) getChannelableStatus(ctx context.Context, bc *duckv1alpha1.
 	}
 	channelableStatus.Status = bc.Status
 	if cAnnotations != nil &&
-		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" {
+		cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1" || cAnnotations[messaging.SubscribableDuckVersionAnnotation] == "v1beta1" {
 		subs := make([]eventingduckv1.SubscriberStatus, len(bc.SubscribableStatus.Subscribers))
 		for i, sub := range bc.SubscribableStatus.Subscribers {
 			sub.ConvertTo(ctx, &subs[i])


### PR DESCRIPTION
This fixes the failing conformance tests at https://github.com/knative/eventing/pull/3871#issuecomment-676205291

I gave it a try here: https://github.com/knative/eventing/pull/3890